### PR TITLE
add parse flag: default is empty

### DIFF
--- a/slackcat.go
+++ b/slackcat.go
@@ -55,7 +55,7 @@ type SlackMsg struct {
 	Channel   string `json:"channel"`
 	Username  string `json:"username,omitempty"`
 	Text      string `json:"text"`
-	Parse     string `json:"parse"`
+	Parse     string `json:"parse,omitempty"`
 	IconEmoji string `json:"icon_emoji,omitempty"`
 }
 
@@ -121,6 +121,7 @@ func main() {
 	channel := pflag.StringP("channel", "c", cfg.Channel, "channel")
 	name := pflag.StringP("name", "n", defaultName, "name")
 	icon := pflag.StringP("icon", "i", "", "icon")
+	parse := pflag.StringP("parse", "p", "", "parse")
 	pflag.Parse()
 
 	// was there a message on the command line? If so use it.
@@ -129,7 +130,7 @@ func main() {
 		msg := SlackMsg{
 			Channel:   *channel,
 			Username:  *name,
-			Parse:     "full",
+			Parse:     *parse,
 			Text:      strings.Join(args, " "),
 			IconEmoji: *icon,
 		}
@@ -147,7 +148,7 @@ func main() {
 		msg := SlackMsg{
 			Channel:   *channel,
 			Username:  *name,
-			Parse:     "full",
+			Parse:     *parse,
 			Text:      scanner.Text(),
 			IconEmoji: *icon,
 		}


### PR DESCRIPTION
allows to send link with `pipe` format (`<https://google.com|google>`), e.g.

[Links look like this](https://google.com)

[slack message builder](https://api.slack.com/docs/messages/builder?msg=%7B%22text%22%3A%22This%20is%20a%20%3Chttps%3A%2F%2Fgoogle.com%7Cgoogle%3E.%22%7D)
